### PR TITLE
added AUR package in installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ sudo apt install gcc make checkinstall python3-psutil python3-pip
 sudo pip install mpris-server
 sudo make install-deb
 
+# on Archlinux
+paru birdie-alarm-moblie-git
+
 # or generic:
 pip3 install -r requirements.txt
 sudo make install
@@ -41,6 +44,9 @@ sudo make install
 ```
 # on Mobian/Debian:
 sudo dpkg -r birdie
+
+# on Archlinux
+pacman -R birdie-alarm-moblie-git
 
 # or generic:
 make uninstall


### PR DESCRIPTION
Hi. I've created a [PKGBUILD](https://aur.archlinux.org/packages/birdie-alarm-mobile-git/) for birdie.

Note that I named it `birdie-alarm-mobile-git` beacause there's already a `birdie-git` package (a tweeter client, https://github.com/arcbtc/birdie the project seems abandonned since 2015), so `birdie-mobile-git` would be confusing (is it a mobile-friendly port of birdie-git?).

At the moment it conflicts with `birdie-git` (`/bin/birdie`...) but I doubt anyone installs birdie-git, and the Twitter  API it uses is probably outdated, now.